### PR TITLE
Flang v20.1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+staging_channel_upload_target: llvm-20.1.8-stage0-build-1
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: llvm-20.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-staging_channel_upload_target: llvm-20.1.8-stage0-build-1
+staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,6 @@ c_compiler:    # [win]
   - vs2022     # [win]
 cxx_compiler:  # [win]
   - vs2022     # [win]
+
+c_stdlib_version:  # [win]
+  - 2022.14        # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,8 @@ cxx_compiler:  # [win]
 
 c_stdlib_version:  # [win]
   - 2022.14        # [win]
+
+c_compiler_version:   # [osx]
+  - 20.1.8            # [osx]
+cxx_compiler_version: # [osx]
+  - 20.1.8            # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,6 @@ source:
 
 build:
   number: 0
-  # intentionally only windows
-  skip: true  # [not win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - lit =={{ version }}
     - llvmdev =={{ version }}
     - mlir =={{ version }}
+    - libmlir =={{ version }}
     - zlib
 
 outputs:
@@ -45,6 +46,7 @@ outputs:
         - compiler-rt =={{ version }}
         - llvmdev =={{ version }}
         - mlir =={{ version }}
+        - libmlir =={{ version }}
     test:
       commands:
         # shared lib on linux
@@ -72,6 +74,7 @@ outputs:
         - llvmdev =={{ version }}
         - mlir =={{ version }}
         # for required run-exports
+        - libmlir =={{ version }}
         - llvm =={{ version }}
         - libclang-cpp =={{ version }}
         # ninja really wants to find z.lib on win

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,8 +93,13 @@ outputs:
 about:
   home: https://flang.llvm.org
   license: Apache-2.0
+  license_family: Apache
   license_file: flang/LICENSE.TXT
+  doc_url: https://flang.llvm.org/docs/
   summary: Flang is a Fortran compiler targeting LLVM.
+  description: |
+    Flang is a Fortran compiler targeting LLVM. It is designed to integrate 
+    with the LLVM ecosystem and provides a modern Fortran compiler implementation.
   dev_url: https://github.com/llvm/llvm-project
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 0
+  # TODO: Skipping osx until https://github.com/llvm/llvm-project/issues/154960 is resolved.
+  skip: true  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  # intentionally only windows (main target) & linux (debuggability)
-  skip: true  # [osx]
+  # intentionally only windows
+  skip: true  # [not win]
 
 requirements:
   build:
@@ -103,6 +103,8 @@ about:
   dev_url: https://github.com/llvm/llvm-project
 
 extra:
+  skip-lints:
+    - should_use_compilers
   recipe-maintainers:
     - isuruf
     - h-vetinari


### PR DESCRIPTION
flang v20.1.8

## Links
- [PKG-8681](https://anaconda.atlassian.net/browse/PKG-8681)
- [Artifacts](https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0)

## Changes
- Build with llvm 20
- Fix overlinking by providing missing libmlir
- Skip OSX for now. Support will be added in a future release.

## Notes
- This is a freshly forked feedstock.
- Linter errors appear to be false negatives.

## Related PRs
- ✅ https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/17
- ✅  https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/23
- https://github.com/AnacondaRecipes/libcxx-feedstock/pull/15
- https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/29
- https://github.com/AnacondaRecipes/clangdev-feedstock/pull/16
- https://github.com/AnacondaRecipes/compiler-rt-feedstock/pull/9
-  ✅ https://github.com/AnacondaRecipes/mlir-feedstock/pull/8
-  ✅ https://github.com/AnacondaRecipes/lld-feedstock/pull/12
- https://github.com/AnacondaRecipes/openmp-feedstock/pull/6
- https://github.com/AnacondaRecipes/clang-win-activation-feedstock/pull/6
- https://github.com/AnacondaRecipes/flang-feedstock/pull/2
- https://github.com/AnacondaRecipes/flang-activation-feedstock/pull/1


[PKG-8678]: https://anaconda.atlassian.net/browse/PKG-8678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-8681]: https://anaconda.atlassian.net/browse/PKG-8681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ