### PR TITLE
Update to LLVM 21.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,12 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
+# Stage 2: Build with clang 21 compiler
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0
+
+channels:
+  # Stage 2 channel has clang_bootstrap 21
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  # Stage 0 channel has supporting packages
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,11 +2,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 2: Build with clang 21 compiler
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0
+# Extend timeout to 4 hours for Windows builds
+task_timeout: 14400
 
-channels:
-  # Stage 2 channel has clang_bootstrap 21
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-  # Stage 0 channel has supporting packages
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage0-build-0
+# Upload to staging so openmp can use flang before main release
+staging_channel_upload_target: llvm-21.1.8-stage2-build-0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,6 @@ c_stdlib_version:  # [win]
   - 2022.14        # [win]
 
 c_compiler_version:   # [osx]
-  - 20.1.8            # [osx]
+  - 21.1.8            # [osx]
 cxx_compiler_version: # [osx]
-  - 20.1.8            # [osx]
+  - 21.1.8            # [osx]

--- a/recipe/install_libflang.bat
+++ b/recipe/install_libflang.bat
@@ -1,4 +1,0 @@
-@echo on
-
-cp build\lib\FortranRuntime.lib %LIBRARY_LIB%
-cp build\lib\FortranDecimal.lib %LIBRARY_LIB%

--- a/recipe/install_libflang.sh
+++ b/recipe/install_libflang.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -ex
-
-# copy symlink & its target, e.g. libFortranRuntime.so.16 & libFortranRuntime.so
-cp $SRC_DIR/build/lib/libFortranRuntime*${SHLIB_EXT}* $PREFIX/lib
-# same for libFortranDecimal
-cp $SRC_DIR/build/lib/libFortranDecimal*${SHLIB_EXT}* $PREFIX/lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ outputs:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clang =={{ version }}
         - compiler-rt =={{ version }}   # [win]
+        - libmlir =={{ version }}       # [linux]
     test:
       commands:
         - test -f $PREFIX/bin/flang                     # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ outputs:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clang =={{ version }}
         - compiler-rt =={{ version }}   # [win]
-        - libmlir =={{ version }}       # [linux]
+        - libmlir21 =={{ version }}      # [linux]
     test:
       commands:
         - test -f $PREFIX/bin/flang                     # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,38 +30,12 @@ requirements:
     - lit =={{ version }}
     - llvmdev =={{ version }}
     - mlir =={{ version }}
-    - libmlir =={{ version }}
     - zlib
 
 outputs:
-  - name: libflang
-    script: install_libflang.sh  # [unix]
-    script: install_libflang.bat  # [win]
-    requirements:
-      build:
-        # for strong run-exports
-        - {{ compiler('c') }}
-        - {{ stdlib('c') }}
-        - {{ compiler('cxx') }}
-      host:
-        - clangdev =={{ version }}
-        - compiler-rt =={{ version }}
-        - llvmdev =={{ version }}
-        - mlir =={{ version }}
-        - libmlir =={{ version }}
-    test:
-      commands:
-        # shared lib on linux
-        - test -f $PREFIX/lib/libFortranRuntime.so              # [linux]
-        # static lib on win (fails to export symbols for shared build)
-        - if not exist %LIBRARY_LIB%\FortranRuntime.lib exit 1  # [win]
-
   - name: flang
     script: install_flang.sh  # [unix]
     script: install_flang.bat  # [win]
-    run_exports:
-      strong:
-        - libflang >={{ version }}
     requirements:
       build:
         - cmake
@@ -76,18 +50,15 @@ outputs:
         - llvmdev =={{ version }}
         - mlir =={{ version }}
         # for required run-exports
-        - libmlir =={{ version }}
         - llvm =={{ version }}
         - libclang-cpp =={{ version }}
         # ninja really wants to find z.lib on win
         - zlib  # [win]
         - zstd  # [win]
-        - {{ pin_subpackage('libflang', exact=True) }}
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clang =={{ version }}
         - compiler-rt =={{ version }}   # [win]
-        - {{ pin_subpackage('libflang', exact=True) }}
     test:
       commands:
         - test -f $PREFIX/bin/flang                     # [linux]
@@ -101,7 +72,7 @@ about:
   doc_url: https://flang.llvm.org/docs/
   summary: Flang is a Fortran compiler targeting LLVM.
   description: |
-    Flang is a Fortran compiler targeting LLVM. It is designed to integrate 
+    Flang is a Fortran compiler targeting LLVM. It is designed to integrate
     with the LLVM ecosystem and provides a modern Fortran compiler implementation.
   dev_url: https://github.com/llvm/llvm-project
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.1.8" %}
+{% set version = "21.1.8" %}
 
 package:
   name: flang-split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
+  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
 
 build:
   number: 0


### PR DESCRIPTION
                                                                                                                                                       
  ## flang 21.1.8                                                                                                                                        
                                                                                                                                                         
  **Destination channel:** defaults                                                                                                                      
                                                                                                                                                         
### Links                                                                                                                
                                                                                                                           
  - [PKG-10608](https://anaconda.atlassian.net/browse/PKG-10608)                                                           
  - [Upstream repository](https://github.com/llvm/llvm-project)                                                            
  - [Upstream changelog/diff](https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.8)                            
  - Relevant dependency PRs:                                                                                               
    - AnacondaRecipes/llvmdev-feedstock#33                                                                                 
    - AnacondaRecipes/clangdev-feedstock#21                                                                                
    - AnacondaRecipes/compiler-rt-feedstock#10                                                                             
    - AnacondaRecipes/mlir-feedstock#10                                                                                    
                                                                                                                           
  ### Explanation of changes:                                                                                              
                                                                                                                           
  - Update version from 20.1.8 to 21.1.8                                                                                   
  - Remove `libflang` output (LLVM 21 no longer builds libFortranRuntime as shared library)                                
  - Add `libmlir21` to run requirements on Linux for overlinking fix                                                       
  - Skip macOS build due to upstream issue (https://github.com/llvm/llvm-project/issues/154960)                            
  - Increase build timeout to 4 hours for Windows                                                                          
                                                                                                               
                                                                                                                                                                                                                                                               
                                                                                                                                                         
  ### Dependencies                   

- ...


[PKG-10608]: https://anaconda.atlassian.net/browse/PKG-10608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ