### PR TITLE
flang 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,3 @@ build_parameters:
 
 # Extend timeout to 4 hours for Windows builds
 task_timeout: 14400
-
-# Upload to staging so openmp can use flang before main release
-staging_channel_upload_target: llvm-21.1.8-stage2-build-0

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,12 +1,4 @@
-c_compiler:    # [win]
-  - vs2022     # [win]
-cxx_compiler:  # [win]
-  - vs2022     # [win]
-
-c_stdlib_version:  # [win]
-  - 2022.14        # [win]
-
 c_compiler_version:   # [osx]
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]
 cxx_compiler_version: # [osx]
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 
 package:
   name: flang-split
@@ -6,11 +6,13 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+  sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
 
 build:
   number: 0
-  # TODO: Skipping osx until https://github.com/llvm/llvm-project/issues/154960 is resolved.
+  # Skipping osx: upstream llvm/llvm-project#154960 ("a dialect with
+  # namespace 'arith' has already been registered") is still OPEN as of
+  # LLVM 22.1.2 (verified 2026-04-07). Re-enable once upstream fixes it.
   skip: true  # [osx]
 
 requirements:
@@ -59,7 +61,7 @@ outputs:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clang =={{ version }}
         - compiler-rt =={{ version }}   # [win]
-        - libmlir21 =={{ version }}      # [linux]
+        - libmlir22 =={{ version }}      # [linux]
     test:
       commands:
         - test -f $PREFIX/bin/flang                     # [linux]


### PR DESCRIPTION
flang 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13443](https://anaconda.atlassian.net/browse/PKG-13443)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog/diff](https://github.com/llvm/llvm-project/compare/llvmorg-21.1.8...llvmorg-22.1.2)
- Relevant dependency PRs:
  - llvmdev: AnacondaRecipes/llvmdev-feedstock#36 
  - clangdev: AnacondaRecipes/clangdev-feedstock#23 
  - compiler-rt: AnacondaRecipes/compiler-rt-feedstock#11
  - clang-compiler-activation: AnacondaRecipes/clang-compiler-activation-feedstock#28
  - lld: AnacondaRecipes/lld-feedstock#14 
  - mlir: AnacondaRecipes/mlir-feedstock#11 

### Explanation of changes:

- Version bump 21.1.8 → 22.1.2

[PKG-13443]: https://anaconda.atlassian.net/browse/PKG-13443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ