### PR TITLE
flang win-arm64 compat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,12 +1,7 @@
 @echo on
 
-:: show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
-python -c "import numpy; numpy.show_config()"
-
 mkdir build
 cd build
-
-set "PROCESSOR_ARCHITECTURE=AMD64"
 
 :: necessary when compiling with clang (which has a native uint128 type; msvc doesn't)
 :: set "CXXFLAGS=%CXXFLAGS% -DAVOID_NATIVE_UINT128_T=1"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 
-# show CPU arch to detect slow CI agents early (rather than wait for 6h timeout)
-python -c "import numpy; numpy.show_config()"
-
 mkdir build
 cd build
 

--- a/recipe/install_libflang.bat
+++ b/recipe/install_libflang.bat
@@ -1,4 +1,4 @@
 @echo on
 
-cp build\lib\FortranRuntime.lib %LIBRARY_LIB%
-cp build\lib\FortranDecimal.lib %LIBRARY_LIB%
+copy /Y "build\lib\FortranRuntime.lib" "%LIBRARY_LIB%\"
+copy /Y "build\lib\FortranDecimal.lib" "%LIBRARY_LIB%\"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,6 @@ requirements:
     # some bug with misinterpreting `...\tools` as a tab (`\t`)
     - ninja <1.13
     - mlir =={{ version }}     # [build_platform != target_platform]
-    # for showing CPU info of CI agent
-    - numpy *
   host:
     - clangdev =={{ version }}
     - compiler-rt =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     # some bug with misinterpreting `...\tools` as a tab (`\t`)
-    - ninja <1.13
+    - ninja
     - mlir =={{ version }}     # [build_platform != target_platform]
   host:
     - clangdev =={{ version }}
@@ -63,7 +63,7 @@ outputs:
     requirements:
       build:
         - cmake
-        - ninja <1.13
+        - ninja
         # for strong run-exports
         - {{ compiler('c') }}
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
     requirements:
       build:
         - cmake
-        - ninja
+        - ninja-base
         # for strong run-exports
         - {{ compiler('c') }}
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - lit =={{ version }}
     - llvmdev =={{ version }}
     - mlir =={{ version }}
-    - zlib
+    - zlib {{ zlib }}
 
 outputs:
   - name: flang
@@ -52,8 +52,8 @@ outputs:
         - llvm =={{ version }}
         - libclang-cpp =={{ version }}
         # ninja really wants to find z.lib on win
-        - zlib  # [win]
-        - zstd  # [win]
+        - zlib {{ zlib }}  # [win]
+        - zstd {{ zstd }}  # [win]
       run:
         - sysroot_{{ target_platform }} >={{ c_stdlib_version }}    # [linux]
         - clang =={{ version }}


### PR DESCRIPTION
flang win-arm64 support

**Destination channel:** defaults

### Links

- [PKG-15381](https://anaconda.atlassian.net/browse/PKG-15381) 

### Explanation of changes:

- Bump build number
- Remove calls to numpy not needed, and remove dependency
- Loosen pinning on ninja and switch to ninja-base
- Remove build_parameters override in abs.yaml


[PKG-15381]: https://anaconda.atlassian.net/browse/PKG-15381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ